### PR TITLE
Feat/add litellm provider

### DIFF
--- a/src/__tests__/providerConfig.test.ts
+++ b/src/__tests__/providerConfig.test.ts
@@ -63,6 +63,28 @@ describe("provider config normalization", () => {
     ).toBe("OpenAI Compatible");
   });
 
+  it("accepts LiteLLM as a valid provider type", () => {
+    const provider = normalizeModelProvider({
+      id: "LITELLM",
+      name: "LiteLLM Proxy",
+      type: "LiteLLM",
+      baseUrl: "http://localhost:4000",
+      apiKey: "sk-litellm-key",
+      models: ["gpt-4o", "claude-sonnet-4-20250514"],
+      modelsList: ["gpt-4o", "claude-sonnet-4-20250514"],
+    });
+
+    expect(provider).toMatchObject({
+      id: "LITELLM",
+      name: "LiteLLM Proxy",
+      type: "LiteLLM",
+      baseUrl: "http://localhost:4000",
+      apiKey: "sk-litellm-key",
+      models: ["gpt-4o", "claude-sonnet-4-20250514"],
+      modelsList: ["gpt-4o", "claude-sonnet-4-20250514"],
+    });
+  });
+
   it("defaults unknown provider types to OpenAI Compatible", () => {
     expect(
       normalizeModelProvider({

--- a/src/__tests__/providerOutbound.test.ts
+++ b/src/__tests__/providerOutbound.test.ts
@@ -62,4 +62,46 @@ describe("provider outbound policy", () => {
       }),
     ).not.toThrow();
   });
+
+  it("creates an OpenAI-compatible client for LiteLLM with a custom base URL", async () => {
+    const { ProviderFactory } = await import("../lib/providers/base");
+
+    expect(() =>
+      ProviderFactory.createOpenAIClient({
+        type: "LiteLLM",
+        baseUrl: "https://litellm.example.com/v1",
+        apiKey: "sk-litellm-key",
+      }),
+    ).not.toThrow();
+  });
+
+  it("blocks LiteLLM default localhost URL in hosted mode", async () => {
+    vi.stubEnv("DEPLOYMENT_MODE", "hosted");
+    lookupMock.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
+
+    const { ProviderFactory } = await import("../lib/providers/base");
+
+    await expect(
+      ProviderFactory.assertProviderOutboundAllowed({
+        type: "LiteLLM",
+        baseUrl: "http://localhost:4000/v1",
+        apiKey: "sk-litellm-key",
+      }),
+    ).rejects.toMatchObject({
+      code: "HOSTED_PROXY_BLOCKED",
+    });
+  });
+
+  it("allows LiteLLM with a public base URL in hosted mode", async () => {
+    vi.stubEnv("DEPLOYMENT_MODE", "hosted");
+    const { ProviderFactory } = await import("../lib/providers/base");
+
+    expect(() =>
+      ProviderFactory.createOpenAIClient({
+        type: "LiteLLM",
+        baseUrl: "https://litellm.example.com/v1",
+        apiKey: "sk-litellm-key",
+      }),
+    ).not.toThrow();
+  });
 });

--- a/src/__tests__/providerRuntimeSchema.test.ts
+++ b/src/__tests__/providerRuntimeSchema.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it } from "vitest";
 import { ProviderRuntimeConfigSchema } from "../lib/api/schemas";
 
 describe("provider runtime schema", () => {
-  it("accepts Gemini, OpenAI, and OpenAI Compatible provider types", () => {
+  it("accepts Gemini, OpenAI, LiteLLM, and OpenAI Compatible provider types", () => {
     expect(ProviderRuntimeConfigSchema.parse({ type: "Gemini" }).type).toBe(
       "Gemini",
     );
     expect(ProviderRuntimeConfigSchema.parse({ type: "OpenAI" }).type).toBe(
       "OpenAI",
+    );
+    expect(ProviderRuntimeConfigSchema.parse({ type: "LiteLLM" }).type).toBe(
+      "LiteLLM",
     );
     expect(
       ProviderRuntimeConfigSchema.parse({ type: "OpenAI Compatible" }).type,

--- a/src/__tests__/urlPolicy.test.ts
+++ b/src/__tests__/urlPolicy.test.ts
@@ -38,6 +38,36 @@ describe("url policy and provider runtime helpers", () => {
     ).toBe("https://compat.example.com/v1");
   });
 
+  it("returns default LiteLLM base URL when no URL is provided", () => {
+    expect(normalizeProviderBaseUrl(undefined, "LiteLLM")).toBe(
+      "http://localhost:4000/v1",
+    );
+    expect(normalizeProviderBaseUrl("default", "LiteLLM")).toBe(
+      "http://localhost:4000/v1",
+    );
+  });
+
+  it("preserves /v1 suffix on custom LiteLLM base URLs", () => {
+    expect(
+      normalizeProviderBaseUrl("https://litellm.example.com/v1", "LiteLLM"),
+    ).toBe("https://litellm.example.com/v1");
+  });
+
+  it("appends /v1 to custom LiteLLM base URLs without it", () => {
+    expect(
+      normalizeProviderBaseUrl("https://litellm.example.com", "LiteLLM"),
+    ).toBe("https://litellm.example.com/v1");
+  });
+
+  it("returns LiteLLM models URL under /v1/models", () => {
+    expect(getProviderModelsUrl(undefined, "LiteLLM")).toBe(
+      "http://localhost:4000/v1/models",
+    );
+    expect(
+      getProviderModelsUrl("https://litellm.example.com", "LiteLLM"),
+    ).toBe("https://litellm.example.com/v1/models");
+  });
+
   it("keeps Gemini SDK base URL at the service root", () => {
     expect(
       normalizeProviderBaseUrl(

--- a/src/__tests__/urlPolicy.test.ts
+++ b/src/__tests__/urlPolicy.test.ts
@@ -63,9 +63,9 @@ describe("url policy and provider runtime helpers", () => {
     expect(getProviderModelsUrl(undefined, "LiteLLM")).toBe(
       "http://localhost:4000/v1/models",
     );
-    expect(
-      getProviderModelsUrl("https://litellm.example.com", "LiteLLM"),
-    ).toBe("https://litellm.example.com/v1/models");
+    expect(getProviderModelsUrl("https://litellm.example.com", "LiteLLM")).toBe(
+      "https://litellm.example.com/v1/models",
+    );
   });
 
   it("keeps Gemini SDK base URL at the service root", () => {

--- a/src/components/settings/ProviderSettings.tsx
+++ b/src/components/settings/ProviderSettings.tsx
@@ -117,6 +117,10 @@ const ProviderSettings = () => {
       label: t("openaiResponses"),
     },
     {
+      value: "LiteLLM",
+      label: "LiteLLM",
+    },
+    {
       value: "Gemini",
       label: "Gemini",
     },

--- a/src/lib/api/schemas.ts
+++ b/src/lib/api/schemas.ts
@@ -51,7 +51,7 @@ function omitPlainSecretField<
 
 export const ProviderRuntimeConfigSchema = z
   .object({
-    type: z.enum(["OpenAI", "Gemini", "OpenAI Compatible"]),
+    type: z.enum(["OpenAI", "Gemini", "LiteLLM", "OpenAI Compatible"]),
     source: z.literal("server-default").optional(),
     apiKey: z.unknown().optional(),
     apiKeySecret: EncryptedSecretEnvelopeSchema.optional(),

--- a/src/lib/providers/base.ts
+++ b/src/lib/providers/base.ts
@@ -67,7 +67,7 @@ export class ProviderFactory {
    */
   static createOpenAIClient(provider: ProviderConfig): OpenAI {
     const apiKey = this.validateApiKey(provider);
-    const baseURL = this.getEffectiveBaseUrl(provider.baseUrl, "OpenAI");
+    const baseURL = this.getEffectiveBaseUrl(provider.baseUrl, provider.type);
     if (baseURL) {
       validateOutboundUrl(baseURL, getSafeUrlPolicy("provider"));
     }

--- a/src/lib/providers/providerTypes.ts
+++ b/src/lib/providers/providerTypes.ts
@@ -3,20 +3,26 @@ import type { ProviderType } from "../../types";
 export const OPENAI_PROVIDER_TYPE = "OpenAI" as const;
 export const OPENAI_COMPATIBLE_PROVIDER_TYPE = "OpenAI Compatible" as const;
 export const GEMINI_PROVIDER_TYPE = "Gemini" as const;
+export const LITELLM_PROVIDER_TYPE = "LiteLLM" as const;
 
 export function isProviderType(value: unknown): value is ProviderType {
   return (
     value === GEMINI_PROVIDER_TYPE ||
     value === OPENAI_PROVIDER_TYPE ||
-    value === OPENAI_COMPATIBLE_PROVIDER_TYPE
+    value === OPENAI_COMPATIBLE_PROVIDER_TYPE ||
+    value === LITELLM_PROVIDER_TYPE
   );
 }
 
 export function isOpenAIProviderType(
   value: unknown,
 ): value is
-  typeof OPENAI_PROVIDER_TYPE | typeof OPENAI_COMPATIBLE_PROVIDER_TYPE {
+  | typeof OPENAI_PROVIDER_TYPE
+  | typeof OPENAI_COMPATIBLE_PROVIDER_TYPE
+  | typeof LITELLM_PROVIDER_TYPE {
   return (
-    value === OPENAI_PROVIDER_TYPE || value === OPENAI_COMPATIBLE_PROVIDER_TYPE
+    value === OPENAI_PROVIDER_TYPE ||
+    value === OPENAI_COMPATIBLE_PROVIDER_TYPE ||
+    value === LITELLM_PROVIDER_TYPE
   );
 }

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -1,6 +1,6 @@
 import type { LocalEncryptedSecretEnvelope } from "../security/localSecrets";
 
-export type ProviderType = "Gemini" | "OpenAI" | "OpenAI Compatible";
+export type ProviderType = "Gemini" | "LiteLLM" | "OpenAI" | "OpenAI Compatible";
 
 export interface ModelProvider {
   id: string;

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -1,6 +1,7 @@
 import type { LocalEncryptedSecretEnvelope } from "../security/localSecrets";
 
-export type ProviderType = "Gemini" | "LiteLLM" | "OpenAI" | "OpenAI Compatible";
+export type ProviderType =
+  "Gemini" | "LiteLLM" | "OpenAI" | "OpenAI Compatible";
 
 export interface ModelProvider {
   id: string;

--- a/src/lib/security/urlPolicy.ts
+++ b/src/lib/security/urlPolicy.ts
@@ -51,12 +51,14 @@ export interface ProviderRuntimeConfig {
 
 const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 const DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com";
+const DEFAULT_LITELLM_BASE_URL = "http://localhost:4000/v1";
 
 export function normalizeProviderBaseUrl(
   baseUrl: string | undefined,
   providerType: ProviderRuntimeConfig["type"] | string,
 ): string {
   if (!baseUrl || baseUrl === "default") {
+    if (providerType === "LiteLLM") return DEFAULT_LITELLM_BASE_URL;
     return isOpenAIProviderType(providerType)
       ? DEFAULT_OPENAI_BASE_URL
       : DEFAULT_GEMINI_BASE_URL;

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -17,7 +17,7 @@ import { logDevError } from "../lib/utils/devLogger";
  * Provider 配置接口
  */
 export interface ProviderConfig {
-  type: "OpenAI" | "Gemini" | "OpenAI Compatible";
+  type: "OpenAI" | "Gemini" | "LiteLLM" | "OpenAI Compatible";
   apiKey?: string;
   baseUrl?: string;
 }


### PR DESCRIPTION
## Summary

- Adds [LiteLLM](https://github.com/BerriAI/litellm) as a first-class provider type in Neo Chat, giving users access to 100+ LLM providers (AWS Bedrock, Azure, Vertex AI, Cohere, Replicate, etc.) through a single proxy endpoint.
- Includes proper base URL resolution, outbound security validation, and comprehensive tests.
- Fixes a pre-existing bug where `createOpenAIClient()` hardcoded `"OpenAI"` for base URL resolution instead of using the actual provider type.

## Test Plan

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (850 passed, 171 suites)
- [x] `pnpm build`

## Notes

- [ ] I updated docs or examples when behavior changed.
- [x] I considered local-first data handling and hosted deployment safety.
- [x] I added or updated tests for user-facing or security-sensitive changes.
- [ ] For localization changes, I followed `docs/localization-pr-guide.md` and documented intentional English fallbacks.\

### Changes

**Provider registration (7 files):**
- `src/lib/providers/types.ts` - Added `"LiteLLM"` to `ProviderType` union
- `src/lib/providers/providerTypes.ts` - Added `LITELLM_PROVIDER_TYPE` constant, updated `isProviderType()` and `isOpenAIProviderType()`
- `src/lib/api/schemas.ts` - Added `"LiteLLM"` to the Zod runtime validation enum
- `src/lib/security/urlPolicy.ts` - Added default LiteLLM base URL (`http://localhost:4000/v1`)
- `src/utils/apiHelpers.ts` - Added `"LiteLLM"` to the `ProviderConfig` type union
- `src/components/settings/ProviderSettings.tsx` - Added LiteLLM to provider type dropdown


**Tests (4 files, +100 lines):**
- `src/__tests__/providerRuntimeSchema.test.ts` - LiteLLM schema validation
- `src/__tests__/urlPolicy.test.ts` - 5 tests: default URL, custom URL with/without `/v1`, models path
- `src/__tests__/providerConfig.test.ts` - 1 test: normalizeModelProvider preserves LiteLLM type
- `src/__tests__/providerOutbound.test.ts` - 3 tests: client creation, localhost blocked in hosted mode, public URL allowed

### Example usage

```typescript
// In your app configuration or via the Settings UI:
const provider = {
  type: "LiteLLM" as const,
  baseUrl: "http://localhost:4000/v1",  // default, auto-filled in UI
  apiKey: "sk-your-litellm-key",        // or leave blank if no auth
};

// Models are auto-discovered from the proxy's /v1/models endpoint.
// Any model your LiteLLM proxy serves becomes available:
//   anthropic/claude-sonnet-4-6
//   bedrock/anthropic.claude-v2
//   vertex_ai/gemini-pro
```

### Risk / Compatibility

- **Additive only.** No existing provider types or streaming logic modified.
- **No new dependencies.** LiteLLM proxy speaks the OpenAI protocol.
- **Hosted deployment safe.** LiteLLM's default `localhost:4000` is correctly blocked in hosted mode (tested).
- **Base URL fix benefits all providers.** The `provider.type` fix is a correctness improvement for any future provider type.
